### PR TITLE
Use pathlib to get unimod URI

### DIFF
--- a/AA_stat/utils.py
+++ b/AA_stat/utils.py
@@ -1,25 +1,19 @@
 import os
 import operator
 import logging
-import sys
-
 import pandas as pd
 import numpy as np
 import warnings
 from collections import Counter
 import re
-
-
+import pathlib
 import itertools as it
 from pyteomics import parser, pepxml, mass
 
 logger = logging.getLogger(__name__)
 
 MASS_FORMAT = '{:+.4f}'
-if sys.platform =='linux' or sys.platform == 'linux2' :
-    UNIMOD = mass.Unimod('file://' + os.path.join(os.path.abspath(os.path.dirname(__file__)), 'unimod.xml'))
-elif sys.platform =='win32' or sys.platform == 'cygwin' or sys.platform == 'msys':
-    UNIMOD = mass.Unimod('file:\\\\' + os.path.join(os.path.abspath(os.path.dirname(__file__)).replace(':','|'), 'unimod.xml'))
+UNIMOD = mass.Unimod(pathlib.Path(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'unimod.xml')).as_uri())
 INTERNAL = 5
 DIFF_C13 = mass.calculate_mass(formula='C[13]') - mass.calculate_mass(formula='C')
 H = mass.nist_mass['H+'][0][0]


### PR DESCRIPTION
Simplify the code around Unimod object creation by using the standard library's method of getting a file URI.